### PR TITLE
Switch to nzbgetcom GitHub repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM binhex/arch-int-vpn:latest
-ENV NZBGET_VERSION=21.1
+ENV NZBGET_VERSION=22.0
 # additional files
 ##################
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This Docker includes OpenVPN and WireGuard to ensure a secure and private connec
 
 **Build notes**
 
-Latest stable NZBGet release from Arch Linux repo (v21.0)
+Latest stable NZBGet release from Arch Linux repo (v22.0)
 Latest stable Privoxy release from Arch Linux repo.  
 Latest stable OpenVPN release from Arch Linux repo.  
 Latest stable WireGuard release from Arch Linux repo.

--- a/build/root/install.sh
+++ b/build/root/install.sh
@@ -49,7 +49,7 @@ source aur.sh
 
 # install nzbget
 
-wget -O /tmp/nzbget.run https://github.com/nzbget/nzbget/releases/download/v$NZBGET_VERSION/nzbget-$NZBGET_VERSION-bin-linux.run
+wget -O /tmp/nzbget.run https://github.com/nzbgetcom/nzbget/releases/download/v$NZBGET_VERSION/nzbget-$NZBGET_VERSION-bin-linux.run
 sh /tmp/nzbget.run --destdir /usr/sbin/nzbget_bin
 ln -s /usr/sbin/nzbget_bin/nzbget /usr/sbin/nzbget
 


### PR DESCRIPTION
## Summary
The original GitHub repository, nzbget-ng/nzbget is no longer maintained and is archived. This PR switches to the new [nzbgetcom/nzbget](https://github.com/nzbgetcom/nzbget) repository which was revealed in [this Reddit post](https://www.reddit.com/r/usenet/comments/18yx5a3/nzbgetngnzbget_will_be_merging_into/) and is actively being maintained.

## Changes
* Switch to actively maintained nzbget repository
* Bump to latest nzbget version (22.0)
* README updates

## Testing
Image builds correctly
```
$ docker build -t nzbgetvpn .
[+] Building 44.6s (12/12) FINISHED                                                                      docker:default
 => [internal] load build definition from Dockerfile                                                               0.1s
 => => transferring dockerfile: 1.02kB                                                                             0.0s
 => [internal] load .dockerignore                                                                                  0.1s
 => => transferring context: 2B                                                                                    0.0s
 => [internal] load metadata for docker.io/binhex/arch-int-vpn:latest                                              1.6s
 => [1/7] FROM docker.io/binhex/arch-int-vpn:latest@sha256:18c1523e6f3e9938880b94e1d397a75bb13b1bc932b3fd2b471a0  24.0s
 => => resolve docker.io/binhex/arch-int-vpn:latest@sha256:18c1523e6f3e9938880b94e1d397a75bb13b1bc932b3fd2b471a06  0.1s
 => => sha256:014829145dc4b1aa8a67743c896241b1fe2811d82c3b86ee2284980fe5c5dec2 2.95kB / 2.95kB                     0.2s
 => => sha256:8981650a5ede8e5935f2f7a5d3b0bc8968bd2dcf1b841bf74ed2ec23de78b998 671.53kB / 671.53kB                 0.4s
 => => sha256:6314e92f33bfc7e7e2a5bd0f8efee95b514f2e590505e4b7afbe54871a03446d 4.47kB / 4.47kB                     0.0s
 => => sha256:ba79b0a0040488aa5644cc312e21c0708c3255ff4ee4a5ab5767ac71a730a513 263B / 263B                         0.1s
 => => sha256:18c1523e6f3e9938880b94e1d397a75bb13b1bc932b3fd2b471a06e809e3ff37 1.61kB / 1.61kB                     0.0s
 => => sha256:693a32359fa0458ebb7d385b831b434aeab45b4b2e3e9f6ac1536f7e1fff66f6 2.00kB / 2.00kB                     0.0s
 => => extracting sha256:ba79b0a0040488aa5644cc312e21c0708c3255ff4ee4a5ab5767ac71a730a513                          0.0s
 => => sha256:3e6f6e9c14bc69b1b6542f502800ed377171b3cac2c8905a445507a32aa878a8 5.01kB / 5.01kB                     0.4s
 => => extracting sha256:014829145dc4b1aa8a67743c896241b1fe2811d82c3b86ee2284980fe5c5dec2                          0.0s
 => => sha256:21c1cc086e6b59371ce6eb010baee99ea01b2232fe536cc9526a93f56d367610 231.84MB / 231.84MB                13.2s
 => => extracting sha256:8981650a5ede8e5935f2f7a5d3b0bc8968bd2dcf1b841bf74ed2ec23de78b998                          0.0s
 => => extracting sha256:3e6f6e9c14bc69b1b6542f502800ed377171b3cac2c8905a445507a32aa878a8                          0.0s
 => => sha256:0ae552da78717c66d2ba81b26e4c7cd5e67b479ad90e29f76e8ffd7f35759b15 4.08kB / 4.08kB                     0.6s
 => => sha256:fb0575d9bc7830e8475aaf9aa7d8481544aae28bad5507389aedf65ad947622c 14.84kB / 14.84kB                   0.7s
 => => sha256:e095b91b62b512e66b267f7d743cf8bc82d4c670206082777dd203d833401682 3.32kB / 3.32kB                     0.8s
 => => sha256:aa9c69fd60e49b2ddb5261d64f67ce1f12d74af9d0474db4743a326350a79880 9.44MB / 9.44MB                     3.1s
 => => extracting sha256:21c1cc086e6b59371ce6eb010baee99ea01b2232fe536cc9526a93f56d367610                          9.3s
 => => extracting sha256:0ae552da78717c66d2ba81b26e4c7cd5e67b479ad90e29f76e8ffd7f35759b15                          0.0s
 => => extracting sha256:fb0575d9bc7830e8475aaf9aa7d8481544aae28bad5507389aedf65ad947622c                          0.0s
 => => extracting sha256:e095b91b62b512e66b267f7d743cf8bc82d4c670206082777dd203d833401682                          0.0s
 => => extracting sha256:aa9c69fd60e49b2ddb5261d64f67ce1f12d74af9d0474db4743a326350a79880                          0.5s
 => [internal] load build context                                                                                  0.1s
 => => transferring context: 220.72kB                                                                              0.0s
 => [2/7] ADD build/*.conf /etc/supervisor/conf.d/                                                                 0.3s
 => [3/7] ADD build/root/*.sh /root/                                                                               0.1s
 => [4/7] ADD run/root/*.sh /root/                                                                                 0.1s
 => [5/7] ADD run/nobody/*.sh /home/nobody/                                                                        0.1s
 => [6/7] RUN chmod +x /root/*.sh /home/nobody/*.sh &&  /bin/bash /root/install.sh                                17.6s
 => [7/7] COPY build/cacert.pem /usr/sbin/nzbget_bin/                                                              0.1s
 => exporting to image                                                                                             0.4s
 => => exporting layers                                                                                            0.4s
 => => writing image sha256:e4e4a793ad8750b16cda031f687e821dda57a94613784c861292cc14859e8f1f                       0.0s
 => => naming to docker.io/library/nzbgetvpn                                                                       0.0s
```

Container seems to start ok
```
$ docker run -it --rm nzbgetvpn
Created by...
___.   .__       .__
\_ |__ |__| ____ |  |__   ____ ___  ___
 | __ \|  |/    \|  |  \_/ __ \\  \/  /
 | \_\ \  |   |  \   Y  \  ___/ >    <
 |___  /__|___|  /___|  /\___  >__/\_ \
     \/        \/     \/     \/      \/
   https://hub.docker.com/u/binhex/

2024-01-05 19:12:52.575138 [info] System information Linux 635e11f75b6f 5.15.133.1-microsoft-standard-WSL2 #1 SMP Thu Oct 5 21:02:42 UTC 2023 x86_64 GNU/Linux
2024-01-05 19:12:52.597767 [warn] PUID not defined (via -e PUID), defaulting to '99'
2024-01-05 19:12:52.650597 [warn] PGID not defined (via -e PGID), defaulting to '100'
2024-01-05 19:12:52.706096 [warn] UMASK not defined (via -e UMASK), defaulting to '000'
2024-01-05 19:12:52.724977 [info] Setting permissions recursively on '/config'...
2024-01-05 19:12:52.745879 [info] Deleting files in /tmp (non recursive)...
2024-01-05 19:12:52.768453 [warn] VPN_ENABLED not defined,(via -e VPN_ENABLED), defaulting to 'yes'
2024-01-05 19:12:52.788168 [warn] VPN_CLIENT not defined (via -e VPN_CLIENT), defaulting to 'openvpn'
2024-01-05 19:12:52.807085 [crit] VPN_PROV not defined,(via -e VPN_PROV), exiting...
```

Only Medium vulns found from Trivy scan
```
$ trivy image nzbgetvpn
2024-01-05T12:19:35.075-0700    INFO    Need to update DB
2024-01-05T12:19:35.075-0700    INFO    DB Repository: ghcr.io/aquasecurity/trivy-db
2024-01-05T12:19:35.075-0700    INFO    Downloading DB...
42.12 MiB / 42.12 MiB [---------------------------------------------------------------------] 100.00% 12.76 MiB p/s 3.5s2024-01-05T12:19:39.458-0700    INFO    Vulnerability scanning is enabled
2024-01-05T12:19:39.458-0700    INFO    Secret scanning is enabled
2024-01-05T12:19:39.458-0700    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-01-05T12:19:39.458-0700    INFO    Please see also https://aquasecurity.github.io/trivy/v0.48/docs/scanner/secret/#recommendation for faster secret detection
2024-01-05T12:19:45.743-0700    INFO    Number of language-specific files: 2
2024-01-05T12:19:45.743-0700    INFO    Detecting gobinary vulnerabilities...
2024-01-05T12:19:45.743-0700    INFO    Detecting python-pkg vulnerabilities...
2024-01-05T12:19:45.807-0700    INFO    Table result includes only package filenames. Use '--format json' option to get the full path to the package file.

Python (python-pkg)

Total: 3 (UNKNOWN: 0, LOW: 0, MEDIUM: 3, HIGH: 0, CRITICAL: 0)

┌─────────────────────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────┬─────────────────────────────────────────────────────────────┐
│         Library         │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                            Title                            │
├─────────────────────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼─────────────────────────────────────────────────────────────┤
│ cryptography (PKG-INFO) │ CVE-2023-49083 │ MEDIUM   │ fixed  │ 41.0.5            │ 41.0.6         │ python-cryptography: NULL-dereference when loading PKCS7    │
│                         │                │          │        │                   │                │ certificates                                                │
│                         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2023-49083                  │
├─────────────────────────┼────────────────┤          │        ├───────────────────┼────────────────┼─────────────────────────────────────────────────────────────┤
│ urllib3 (METADATA)      │ CVE-2023-43804 │          │        │ 1.26.15           │ 2.0.6, 1.26.17 │ python-urllib3: Cookie request header isn't stripped during │
│                         │                │          │        │                   │                │ cross-origin redirects                                      │
│                         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2023-43804                  │
│                         ├────────────────┤          │        │                   ├────────────────┼─────────────────────────────────────────────────────────────┤
│                         │ CVE-2023-45803 │          │        │                   │ 2.0.7, 1.26.18 │ urllib3: Request body not stripped after redirect from 303  │
│                         │                │          │        │                   │                │ status changes...                                           │
│                         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2023-45803                  │
└─────────────────────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────┴─────────────────────────────────────────────────────────────┘
```